### PR TITLE
Fix esp-tls server verification error

### DIFF
--- a/TLS_FIX_SUMMARY.md
+++ b/TLS_FIX_SUMMARY.md
@@ -1,0 +1,119 @@
+# ESP-TLS 错误修复总结
+
+## 问题描述
+
+项目中出现以下错误：
+
+```
+E (3246) esp-tls-mbedtls: No server verification option set in esp_tls_cfg_t structure. Check esp_tls API reference
+E (3246) esp-tls-mbedtls: Failed to set client configurations, returned [0x8017] (ESP_ERR_MBEDTLS_SSL_SETUP_FAILED)
+E (3256) esp-tls: create_ssl_handle failed
+E (3256) esp-tls: Failed to open new connection
+E (3266) transport_base: Failed to open a new connection
+E (3266) HTTP_CLIENT: Connection failed, sock < 0
+E (3276) ai_service: HTTP请求错误: ESP_ERR_HTTP_CONNECT
+I (3276) ai_service: HTTP_EVENT_DISCONNECTED
+```
+
+## 问题原因
+
+ESP-IDF 要求在使用 HTTPS 连接时，必须在 `esp_http_client_config_t` 结构中提供服务器验证选项。原始代码中的配置：
+
+```c
+esp_http_client_config_t config = {
+    .url = AI_BASE_URL "/v1/chat/completions",
+    .method = HTTP_METHOD_POST,
+    .event_handler = _http_event_handler,
+    .user_data = response_buffer,
+    .timeout_ms = 15000,
+    .is_async = false,
+    .skip_cert_common_name_check = true,  // 跳过证书验证
+    .use_global_ca_store = false,         // 不使用全局CA存储
+};
+```
+
+这种配置虽然跳过了证书验证，但没有提供任何替代的服务器验证方法，导致 ESP-TLS 无法建立安全连接。
+
+## 解决方案
+
+### 1. 添加必要的头文件
+
+在 `ai_service.c` 中添加：
+```c
+#include "esp_crt_bundle.h"
+```
+
+### 2. 修改 HTTP 客户端配置
+
+将所有三个 HTTP 客户端配置修改为使用证书包验证：
+
+```c
+esp_http_client_config_t config = {
+    .url = AI_BASE_URL "/v1/chat/completions",
+    .method = HTTP_METHOD_POST,
+    .event_handler = _http_event_handler,
+    .user_data = response_buffer,
+    .timeout_ms = 15000,
+    .is_async = false,
+    .crt_bundle_attach = esp_crt_bundle_attach,  // 使用证书包进行服务器验证
+};
+```
+
+### 3. 更新 CMakeLists.txt
+
+在 `components/ai_service/CMakeLists.txt` 中添加 `esp_crt_bundle` 依赖：
+
+```cmake
+idf_component_register(SRCS "ai_service.c" "local_ai_service.c"
+                    INCLUDE_DIRS "."
+                    REQUIRES esp_http_client json mbedtls camera_driver storage_manager wifi_manager motor_driver esp_timer navigation_service esp_crt_bundle
+                    PRIV_REQUIRES esp-tls)
+```
+
+## 修复的优势
+
+1. **安全性**：使用 ESP-IDF 内置的证书包进行服务器验证，确保连接安全
+2. **兼容性**：证书包包含主要的 CA 根证书，支持大多数 HTTPS 服务
+3. **维护性**：不需要手动管理证书，ESP-IDF 会自动更新证书包
+4. **标准合规**：符合 ESP-IDF 的最佳实践和安全要求
+
+## 验证方法
+
+修复后，ESP-TLS 将能够：
+1. 正确验证服务器证书
+2. 建立安全的 HTTPS 连接
+3. 成功发送 AI API 请求
+
+## 相关配置
+
+项目的 `sdkconfig` 中已经启用了必要的配置：
+- `CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y`
+- `CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=y`
+
+这些配置确保了证书包功能可用。
+
+## 其他可选方案
+
+如果证书包方法不适用，还可以考虑：
+
+1. **提供特定 CA 证书**：
+   ```c
+   .cacert_buf = (const unsigned char *)ca_cert_pem_start,
+   .cacert_bytes = ca_cert_pem_end - ca_cert_pem_start,
+   ```
+
+2. **使用全局 CA 存储**：
+   ```c
+   .use_global_ca_store = true,
+   ```
+
+3. **仅用于测试的不安全模式**（不推荐生产环境）：
+   在 `sdkconfig` 中启用：
+   ```
+   CONFIG_ESP_TLS_INSECURE=y
+   CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY=y
+   ```
+
+## 结论
+
+通过使用 ESP-IDF 的证书包功能，我们解决了 ESP-TLS 服务器验证选项缺失的问题，确保了 HTTPS 连接的安全性和可靠性。这是推荐的标准做法，既安全又易于维护。

--- a/components/ai_service/CMakeLists.txt
+++ b/components/ai_service/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "ai_service.c" "local_ai_service.c"
                     INCLUDE_DIRS "."
-                    REQUIRES esp_http_client json mbedtls camera_driver storage_manager wifi_manager motor_driver esp_timer navigation_service
+                    REQUIRES esp_http_client json mbedtls camera_driver storage_manager wifi_manager motor_driver esp_timer navigation_service esp_crt_bundle
                     PRIV_REQUIRES esp-tls)

--- a/components/ai_service/ai_service.c
+++ b/components/ai_service/ai_service.c
@@ -5,6 +5,7 @@
 #include "esp_log.h"
 #include "esp_http_client.h"
 #include "esp_tls.h"
+#include "esp_crt_bundle.h"
 #include "mbedtls/base64.h"
 #include "cJSON.h"
 
@@ -158,9 +159,7 @@ esp_err_t ai_service_analyze_image(camera_fb_t *fb, const char* filename)
         .user_data = response_buffer,
         .timeout_ms = 15000,
         .is_async = false,
-        .skip_cert_common_name_check = true,
-        .use_global_ca_store = false,
-        
+        .crt_bundle_attach = esp_crt_bundle_attach,
     };
     
     esp_http_client_handle_t client = esp_http_client_init(&config);
@@ -281,9 +280,7 @@ static esp_err_t ai_service_execute_command_with_image(camera_fb_t *fb, const ch
         .user_data = response_buffer,
         .timeout_ms = 15000,
         .is_async = false,
-        .skip_cert_common_name_check = true,
-        .use_global_ca_store = false,
-        
+        .crt_bundle_attach = esp_crt_bundle_attach,
     };
     
     esp_http_client_handle_t client = esp_http_client_init(&config);
@@ -469,9 +466,7 @@ esp_err_t ai_service_auto_drive_analyze(camera_fb_t *fb, const char* filename)
         .user_data = response_buffer,
         .timeout_ms = 20000, // Increased timeout
         .is_async = false,
-        .skip_cert_common_name_check = true,
-        .use_global_ca_store = false,
-        
+        .crt_bundle_attach = esp_crt_bundle_attach,
     };
     
     esp_http_client_handle_t client = esp_http_client_init(&config);


### PR DESCRIPTION
Fixes ESP-TLS connection error by enabling server certificate verification using the ESP-IDF certificate bundle.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea1e5467-cbad-48dc-b31a-99ecc9afbb35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea1e5467-cbad-48dc-b31a-99ecc9afbb35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

